### PR TITLE
feat: allow running VS Code Browser with preferred port

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ CLI options:
 | --permission|  Permission granted to the opened browser: e.g. `clipboard-read`, `clipboard-write`.  See [full list of options](https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions). Argument can be provided multiple times.  |
 | --folder-uri | URI of the workspace to open VS Code on. Ignored when `folderPath` is provided |
 | --extensionPath | A path pointing to a folder containing additional extensions to include. Argument can be provided multiple times. |
+| --port | The preferred port number for running the local web server. Defaults to `3000` if not set. |
 | folderPath |  A local folder to open VS Code on. The folder content will be available as a virtual file system and opened as workspace. |
 
 Corresponding options are available in the API.

--- a/package.json
+++ b/package.json
@@ -23,19 +23,21 @@
   },
   "dependencies": {
     "@koa/router": "^10.1.1",
+    "decompress": "^4.2.1",
+    "decompress-targz": "^4.1.1",
+    "get-port": "^5.1.1",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
     "koa": "^2.13.1",
     "koa-morgan": "^1.0.1",
     "koa-mount": "^4.0.0",
     "koa-static": "^5.0.0",
     "minimist": "^1.2.5",
     "playwright": "1.14.1",
-    "vscode-uri": "^3.0.2",
-    "http-proxy-agent": "^4.0.1",
-    "https-proxy-agent": "^5.0.0",
-    "decompress": "^4.2.1",
-    "decompress-targz": "^4.1.1"
+    "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
+    "@types/decompress": "^4.2.4",
     "@types/koa": "^2.13.4",
     "@types/koa-morgan": "^1.0.5",
     "@types/koa-mount": "^4.0.1",
@@ -45,7 +47,6 @@
     "@types/node": "^12.19.9",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
-    "@types/decompress": "^4.2.4",
     "eslint": "^7.32.0",
     "eslint-plugin-header": "^3.1.1",
     "typescript": "^4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+
 get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"


### PR DESCRIPTION
This adds new option `--port` for setting the preferred port number to run the VS Code Browser. 

This PR also slightly changes the behavior when the current port number (`3000` by default) is not available or already in use; 
It will try to run with the next available port number, instead of failing with `EADDRINUSE` exception.
