### PR TITLE
run from sources failes due to Content-Security-Policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-web",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "scripts": {
     "install-extensions": "yarn --cwd=fs-provider && yarn --cwd=sample",
     "compile": "tsc -p ./ && yarn compile-fs-provider",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -39,11 +39,13 @@ export default async function createApp(config: IConfig): Promise<Koa> {
 		})
 	);
 
-	// CSP: frame-ancestors
-	app.use((ctx, next) => {
-		ctx.set('Content-Security-Policy', `frame-ancestors 'none'`);
-		return next();
-	});
+	if (config.build.type !== 'sources') {
+		// CSP: frame-ancestors
+		app.use((ctx, next) => {
+			ctx.set('Content-Security-Policy', `frame-ancestors 'none'`);
+			return next();
+		});
+	}
 
 	// COI
 	app.use((ctx, next) => {


### PR DESCRIPTION
Run `./scripts/code-web.sh` with latest @vscode/test-web

`webWorkerExtensionHost.ts:121 The web worker extension host is started in a same-origin iframe!`
`Refused to frame 'http://localhost:8080/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'none'".`