### PR TITLE
Downgrade to 18.17.x

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -39,13 +39,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 18.x
+              - 18.17.x
           - name: MacOS
             nodeVersions:
-              - 18.x
+              - 18.17.x
           - name: Windows
             nodeVersions:
-              - 18.x
+              - 18.17.x
 
         testSteps:
           - script: yarn --frozen-lockfile


### PR DESCRIPTION
18.18.1 might fix the CI issues, but it just came out yesterday and it doesn't look like CI picked it up yet.

Use 18.17.x for now.