### PR TITLE
Fetch web worker extension host from localhost instead of cdn

### DIFF
--- a/src/server/workbench.ts
+++ b/src/server/workbench.ts
@@ -137,7 +137,11 @@ export default function (config: IConfig): Router.Middleware {
 			const productOverrides = await getProductOverrides(config.build.location);
 			ctx.state.workbench = new Workbench(`${ctx.protocol}://${ctx.host}/static/sources`, true, config.esm, builtInExtensions, productOverrides);
 		} else if (config.build.type === 'static') {
-			ctx.state.workbench = new Workbench(`${ctx.protocol}://${ctx.host}/static/build`, false, config.esm);
+			const baseUrl = `${ctx.protocol}://${ctx.host}/static/build`;
+			const baseUrlTemplate = `${ctx.protocol}://{{uuid}}.${ctx.host}/static/build`;
+			ctx.state.workbench = new Workbench(baseUrl, false, config.esm, [], {
+				webEndpointUrlTemplate: baseUrlTemplate,
+			});
 		} else if (config.build.type === 'cdn') {
 			ctx.state.workbench = new Workbench(config.build.uri, false, config.esm);
 		}


### PR DESCRIPTION
Fixes #106

This change sets the `webEndpointUrlTemplate` product configuration such that the web worker extension host iframe will be fetched from the local server instead of the default `*.vscode-cdn.net` . This should improve reliability in CI environments as it limits interaction with the web.

Since VSCode uses a generated subdomain name for requests, CORS also needs to be configured to allow for requests from that subdomain of `localhost`.