### PR TITLE
Prepare 0.0.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/test-web",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/test-web",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "license": "MIT",
       "dependencies": {
         "@koa/cors": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/test-web",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "scripts": {
     "install-extensions": "npm i --prefix=fs-provider && npm i --prefix=sample",
     "compile": "tsc -p ./ && npm run compile-fs-provider",


### PR DESCRIPTION
This bumps the version to 0.0.50 so a new release can be made to fix the `@koa/cors` security vulnerability.

cc @DonJayamanne