### PR TITLE
Clamp VSCode download to stable release until NLS issue on Insiders is fixed

### DIFF
--- a/src/server/download.ts
+++ b/src/server/download.ts
@@ -20,7 +20,9 @@ interface DownloadInfo {
 }
 
 async function getLatestVersion(quality: 'stable' | 'insider'): Promise<DownloadInfo> {
-	const update: DownloadInfo = await fetchJSON(`https://update.code.visualstudio.com/api/update/web-standalone/${quality}/latest`);
+	// TODO: Remove this once NLS is fixed
+	const qualityOverrideToStable = quality === 'insider' ? 'stable' : quality;
+	const update: DownloadInfo = await fetchJSON(`https://update.code.visualstudio.com/api/update/web-standalone/${qualityOverrideToStable}/latest`);
 	return update;
 }
 


### PR DESCRIPTION
Currently launching VSCode leads to partial crash and unusuable state (mount issues and NLS-related logs in DevTools console).

Root cause indicated by VSCode team suggest latest changes in NLS might have affected it.

Switching from "insider" to "stable" version download fixes the problem.

This PR clamps the version to "stable" and unblocks vscode-test-web functionality again.

The intention is to figure out the necessary change either in vscode-test-web codebase, or in the VSCode itself, while the core functionality is back to working.

See https://github.com/microsoft/vscode/issues/220171 for details of the issue.