### PR TITLE
Update ESM detection for running fom source and CSS module creation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 .vscode
 .npmignore
 .editorconfig
-.eslintrc.js
+.eslint.config.js
 .prettierrc
 .github/
 build/

--- a/views/workbench-esm.html
+++ b/views/workbench-esm.html
@@ -42,26 +42,6 @@
 		globalThis._VSCODE_FILE_ROOT = baseUrl + '/out/';
 	</script>
 	<script>
-		const sheet = document.getElementById('vscode-css-modules').sheet;
-		globalThis._VSCODE_CSS_LOAD = function (url) {
-			sheet.insertRule(`@import url(${url});`);
-		};
-
-		const importMap = { imports: {} };
-		const cssModules = JSON.parse('{{WORKBENCH_DEV_CSS_MODULES}}');
-		for (const cssModule of cssModules) {
-			const cssUrl = new URL(cssModule, globalThis._VSCODE_FILE_ROOT).href;
-			const jsSrc = `globalThis._VSCODE_CSS_LOAD('${cssUrl}');\n`;
-			const blob = new Blob([jsSrc], { type: 'application/javascript' });
-			importMap.imports[cssUrl] = URL.createObjectURL(blob);
-		}
-		const importMapElement = document.createElement('script');
-		importMapElement.type = 'importmap';
-		importMapElement.setAttribute('nonce', '1nline-m4p')
-		importMapElement.textContent = JSON.stringify(importMap, undefined, 2);
-		document.head.appendChild(importMapElement);
-	</script>
-	<script>
 		performance.mark('code/willLoadWorkbenchMain');
 	</script>
 	{{WORKBENCH_MAIN}}


### PR DESCRIPTION

This pull request includes changes to improve the detection of ESM(ECMAScript Modules) and the creation of CSS modules. The `detect ESM with sources` commit updates the ESM detection logic to check if the `package.json` file has a `type` field set to `module`. The `only create css modules when needed` commit modifies the code to create CSS modules only when necessary, reducing unnecessary requests. 