### PR TITLE
VS Code main has moved back to npm, we could catch it

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ CLI options:
 | --extensionTestsPath | A path to a test module to run. |
 | --quality | `insiders` (default),  or `stable`. Ignored when sourcesPath is provided. |
 | --commit | commitHash The servion of the server to use. Defaults to latest build version of the given quality. Ignored when sourcesPath is provided. |
-| --sourcesPath | If set, runs the server from VS Code sources located at the given path. Make sure the sources and extensions are compiled (`yarn compile` and `yarn compile-web`). |
+| --sourcesPath | If set, runs the server from VS Code sources located at the given path. Make sure the sources and extensions are compiled (`npm run compile` and `npm run compile-web`). |
 | --headless | If set, hides the browser. Defaults to true when an extensionTestsPath is provided, otherwise false. |
 | --permission | Permission granted to the opened browser: e.g. `clipboard-read`, `clipboard-write`.  See [full list of options](https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions). Argument can be provided multiple times. |
 | --coi | If set, enables cross origin isolation. Defaults to false. |


### PR DESCRIPTION
Our main repository of VS Code has moving back to npm, about this [issue](https://github.com/microsoft/vscode/issues/196795)

I found that `yarn compile` could work if you have already installed `yarn` globally on your local machine, so even if somebody follows this `README.md` documentation, he/she still could get compiled for VS Code, however else could not instead.