### PR TITLE
Set publishRequiresApproval to false in pipeline configuration

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -69,3 +69,4 @@ extends:
               DISPLAY: ':99.0'
 
         publishPackage: ${{ parameters.publishPackage }}
+        publishRequiresApproval: false


### PR DESCRIPTION
The extra publish approval is not necessary as there's already an approval required when triggering the 'release' ci.