### PR TITLE
fix: handle connection errors on ClientRequest to prevent process crash

### DIFF
--- a/src/server/download.ts
+++ b/src/server/download.ts
@@ -33,7 +33,7 @@ export async function getDownloadURL(quality: 'stable' | 'insider', commit: stri
 				resolve(undefined);
 			}
 			res.resume(); // Discard response body
-		});
+		}).on('error', reject);
 	});
 }
 
@@ -82,7 +82,7 @@ async function downloadAndUntar(downloadUrl: string, destination: string, messag
 				resolve();
 			});
 			extract.on('error', reject);
-		});
+		}).on('error', reject);
 	});
 }
 
@@ -156,10 +156,8 @@ export async function fetch(api: string): Promise<string> {
 				resolve(data);
 			});
 
-			res.on('error', err => {
-				reject(err);
-			});
-		});
+			res.on('error', reject);
+		}).on('error', reject);
 	});
 }
 


### PR DESCRIPTION
This pull request improves error handling in the `src/server/download.ts` file by ensuring that network and stream errors are properly propagated and handled in asynchronous operations. The main changes involve attaching error listeners to network requests and streams to prevent unhandled errors during downloads and fetch operations.

**Error handling improvements:**

* Added `.on('error', reject)` to network request and stream operations in `getDownloadURL`, `downloadAndUntar`, and `fetch` to ensure that errors are correctly propagated and handled by the respective promise rejections. 

Fixes #200